### PR TITLE
[#19] Adding Off-Canvas

### DIFF
--- a/app/assets/stylesheets/buildout_design_system/components/offcanvas.scss
+++ b/app/assets/stylesheets/buildout_design_system/components/offcanvas.scss
@@ -1,0 +1,11 @@
+.offcanvas-header {
+  border-bottom: 1px solid var(--#{$prefix}border-color);
+}
+
+.offcanvas-footer {
+  padding: map-get($spacers, 2);
+  border-top: 1px solid var(--#{$prefix}border-color);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}

--- a/app/components/buildout_design_system/off_canvas.html.slim
+++ b/app/components/buildout_design_system/off_canvas.html.slim
@@ -1,0 +1,7 @@
+.offcanvas class="#{@position} #{@class_name}" *@attrs
+  - if header
+    = header
+  - if body
+    = body
+  - if footer
+    = footer

--- a/app/components/buildout_design_system/off_canvas.rb
+++ b/app/components/buildout_design_system/off_canvas.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class OffCanvas < ViewComponent::Base
+    renders_one :header, OffCanvasHeader
+    renders_one :body, OffCanvasBody
+    renders_one :footer, OffCanvasFooter
+
+    POSITIONS = {
+      start: "offcanvas-start",
+      end: "offcanvas-end",
+      top: "offcanvas-top",
+      bottom: "offcanvas-bottom"
+    }.freeze
+
+    def initialize(class_name: "", position: nil, **attrs)
+      super(**attrs)
+      @class_name = class_name
+      @attrs = attrs
+      @position = POSITIONS.fetch(position&.to_sym, nil) || POSITIONS[:start]
+    end
+  end
+end

--- a/app/components/buildout_design_system/off_canvas/off_canvas_body.html.slim
+++ b/app/components/buildout_design_system/off_canvas/off_canvas_body.html.slim
@@ -1,0 +1,2 @@
+.offcanvas-body class="#{ @class_name }" *@attrs
+  = content

--- a/app/components/buildout_design_system/off_canvas/off_canvas_body.rb
+++ b/app/components/buildout_design_system/off_canvas/off_canvas_body.rb
@@ -1,0 +1,14 @@
+#frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class OffCanvas
+    class OffCanvasBody < ViewComponent::Base
+
+      def initialize(class_name: "", **attrs)
+        super(**attrs)
+        @class_name = class_name
+        @attrs = attrs
+      end
+    end
+  end
+end

--- a/app/components/buildout_design_system/off_canvas/off_canvas_footer.html.slim
+++ b/app/components/buildout_design_system/off_canvas/off_canvas_footer.html.slim
@@ -1,0 +1,2 @@
+.offcanvas-footer class="#{ @class_name }" *@attrs
+  = content

--- a/app/components/buildout_design_system/off_canvas/off_canvas_footer.rb
+++ b/app/components/buildout_design_system/off_canvas/off_canvas_footer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class OffCanvas
+    class OffCanvasFooter < ViewComponent::Base
+
+      def initialize(class_name: "", **attrs)
+        super(**attrs)
+        @class_name = class_name
+        @attrs = attrs
+      end
+    end
+  end
+end

--- a/app/components/buildout_design_system/off_canvas/off_canvas_header.html.slim
+++ b/app/components/buildout_design_system/off_canvas/off_canvas_header.html.slim
@@ -1,0 +1,4 @@
+.offcanvas-header
+  h5.offcanvas-title = @title
+  = render(BuildoutDesignSystem::Button.new({ variant: "secondary", style: "text" }, data: { "bs-dismiss": "offcanvas"}, "aria-label": "Close")) do 
+    i.fas.fa-times

--- a/app/components/buildout_design_system/off_canvas/off_canvas_header.rb
+++ b/app/components/buildout_design_system/off_canvas/off_canvas_header.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class OffCanvas
+    class OffCanvasHeader < ViewComponent::Base
+
+      def initialize(class_name: "", title: '', **attrs)
+        super(**attrs)
+        @class_name = class_name
+        @attrs = attrs
+        @title = title
+      end
+    end
+  end
+end

--- a/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview.rb
@@ -5,11 +5,13 @@ module BuildoutDesignSystem
     # Off Canvas / Side Drawer
     # -------------------------
     # Off Canvas or Side drawers provide a way to display temporary information or action that interrupts the user flow.
+    # @param title text "Title of the Off Canvas"
     # @param position select { choices: [~, start, end, top, bottom] } "Position of the Off Canvas"
     # @param class_name text " Additional Class names for the Off Canvas"
 
-    def default(position: "start", class_name: "")
+    def default(title: "Off Canvas Title", position: "start", class_name: "")
       render_with_template(locals: {
+        title: title,
         position: position,
         class_name: class_name
       })

--- a/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview.rb
@@ -1,0 +1,19 @@
+module BuildoutDesignSystem
+  # @label Off Canvas / Side Drawer
+  class OffCanvasPreview < ViewComponent::Preview
+    # @!group Off Canvas / Side Drawer Styles
+    # Off Canvas / Side Drawer
+    # -------------------------
+    # Off Canvas or Side drawers provide a way to display temporary information or action that interrupts the user flow.
+    # @param position select { choices: [~, start, end, top, bottom] } "Position of the Off Canvas"
+    # @param class_name text " Additional Class names for the Off Canvas"
+
+    def default(position: "start", class_name: "")
+      render_with_template(locals: {
+        position: position,
+        class_name: class_name
+      })
+    end
+    # @!endgroup
+  end
+end

--- a/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview/default.html.slim
@@ -1,0 +1,10 @@
+= render(BuildoutDesignSystem::Button.new({ variant: 'secondary' }, data: { "bs-toggle": "offcanvas", "bs-target": "#offcanvasExample"}))
+  | Open Offcanvas
+
+= render(BuildoutDesignSystem::OffCanvas.new(class_name: class_name, position: position, id: "offcanvasExample")) do |offcanvas|
+  - offcanvas.with_header(title: "Offcanvas Title")
+  - offcanvas.with_body do
+    | Some text as the body of the offcanvas
+  - offcanvas.with_footer do
+    = render(BuildoutDesignSystem::Button.new({ variant: "secondary" }, data: { "bs-dismiss": "offcanvas"})) do 
+      | Close

--- a/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/off_canvas_preview/default.html.slim
@@ -2,9 +2,9 @@
   | Open Offcanvas
 
 = render(BuildoutDesignSystem::OffCanvas.new(class_name: class_name, position: position, id: "offcanvasExample")) do |offcanvas|
-  - offcanvas.with_header(title: "Offcanvas Title")
+  - offcanvas.with_header(title: title)
   - offcanvas.with_body do
-    | Some text as the body of the offcanvas
+    p The Body of the Off Canvas is open to place in other components or content as needed.
   - offcanvas.with_footer do
     = render(BuildoutDesignSystem::Button.new({ variant: "secondary" }, data: { "bs-dismiss": "offcanvas"})) do 
       | Close


### PR DESCRIPTION
I haven't updated the version number, because if we're going to end up working on multiple components at the same time, not sure if we want to start tagging releases to include multiple commits into one release as we make all these other new components?

* Off Canvas will support one specific prop which is placement.
* Additional Classes can be passed onto each sub-components
* Additional Attributes and classes can be passed onto the container of the off-canvas.

Sample on this looks:
![image](https://github.com/buildoutinc/buildout_design_system/assets/61026541/51ee0659-e9ff-4467-9116-ca337ba77476)
