### PR TITLE
#27 Update Tabs Component

### DIFF
--- a/app/components/buildout_design_system/tab_pane.html.slim
+++ b/app/components/buildout_design_system/tab_pane.html.slim
@@ -1,2 +1,2 @@
-.tab-pane class=@class_name id=@name
+.tab-pane class=[@class_name, ("active" if @active)] id=@name
   = content

--- a/app/components/buildout_design_system/tab_pane.rb
+++ b/app/components/buildout_design_system/tab_pane.rb
@@ -2,12 +2,12 @@
 
 module BuildoutDesignSystem
   class TabPane < ViewComponent::Base
-    attr_reader :class_name, :active, :id
-    def initialize(class_name: "", active: false, id: nil)
+    attr_reader :class_name, :active, :name
+    def initialize(class_name: "", active: false, name: nil)
       super()
       @class_name = class_name
       @active = active
-      @id = id
+      @name = name
     end
   end
 end

--- a/app/components/buildout_design_system/tab_panes.html.slim
+++ b/app/components/buildout_design_system/tab_panes.html.slim
@@ -1,0 +1,4 @@
+.tab-content class=@class_name
+  - if tab_panes?
+    - tab_panes.each do | tab_pane |
+      = tab_pane

--- a/app/components/buildout_design_system/tab_panes.rb
+++ b/app/components/buildout_design_system/tab_panes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class TabPanes < ViewComponent::Base
+    renders_many :tab_panes, BuildoutDesignSystem::TabPane
+
+    def initialize(class_name: "", **attrs)
+      super(**attrs)
+      @class_name = class_name
+      @attrs = attrs
+    end
+  end
+end

--- a/app/components/buildout_design_system/tabs.html.slim
+++ b/app/components/buildout_design_system/tabs.html.slim
@@ -1,8 +1,4 @@
-ul.nav class="#{@variant}" role="tablist"
+ul.nav class="#{@variant} #{@direction}" role="tablist"
   - if tabs?
     - tabs.each do | tab |
       = tab
-.tab-content
-  - if tab_panes?
-    - tab_panes.each do | tab_pane |
-      = tab_pane

--- a/app/components/buildout_design_system/tabs.rb
+++ b/app/components/buildout_design_system/tabs.rb
@@ -3,17 +3,23 @@
 module BuildoutDesignSystem
   class Tabs < ViewComponent::Base
     renders_many :tabs, BuildoutDesignSystem::Tab
-    renders_many :tab_panes, BuildoutDesignSystem::TabPane
 
     VARIANTS = {
       default: "nav-tabs",
       pills: "nav-pills",
       square: "nav-pills nav-square",
+      vertical: "nav-pills",
     }.freeze
 
-    def initialize(class_name: "", variant: "nav-tabs", **attrs)
+    DIRECTION = {
+      horizontal: "flex-row",
+      vertical: "flex-column",
+    }
+
+    def initialize(class_name: "", variant: "nav-tabs", direction: DIRECTION[:horizontal], **attrs)
       super(**attrs)
       @variant = VARIANTS.fetch(variant&.to_sym || :default, VARIANTS[:default])
+      @direction = DIRECTION.fetch(direction&.to_sym || :horizontal, DIRECTION[:horizontal])
       @class_name = class_name
       @attrs = attrs
     end

--- a/test/dummy/test/components/previews/buildout_design_system/tabs_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/tabs_preview.rb
@@ -10,5 +10,7 @@ module BuildoutDesignSystem
     def pills; end
 
     def square; end
+
+    def vertical; end
   end
 end

--- a/test/dummy/test/components/previews/buildout_design_system/tabs_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/tabs_preview/default.html.slim
@@ -2,13 +2,14 @@
 = render(BuildoutDesignSystem::Card.new()) do | card |
   
   = render(BuildoutDesignSystem::Tabs.new()) do | tab_container |
-    = tab_container.with_tab(name: "tab1content", label: "Tab 1", active: true)
-    = tab_container.with_tab(name: "tab2content", label: "Tab 2", icon: "fa-otter")
-    
-    = tab_container.with_tab_pane(id: "tab1content", active: true) do
+    = tab_container.with_tab(name: "tab1contentdef", label: "Tab 1", active: true)
+    = tab_container.with_tab(name: "tab2contentdef", label: "Tab 2", icon: "fa-otter")
+
+  = render(BuildoutDesignSystem::TabPanes.new()) do | pane |
+    = pane.with_tab_pane(name: "tab1contentdef", active: true) do
       .p-4
         p Tab 1 Content
     
-    = tab_container.with_tab_pane(id: "tab2content") do
+    = pane.with_tab_pane(name: "tab2contentdef") do
       .p-4
         p Tab 2 Content

--- a/test/dummy/test/components/previews/buildout_design_system/tabs_preview/pills.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/tabs_preview/pills.html.slim
@@ -2,13 +2,14 @@
 = render(BuildoutDesignSystem::Card.new()) do | card |
   
   = render(BuildoutDesignSystem::Tabs.new(variant: "pills")) do | tab_container |
-    = tab_container.with_tab(name: "tab1content", label: "Tab 1", active: true)
-    = tab_container.with_tab(name: "tab2content", label: "Tab 2", icon: "fa-otter")
+    = tab_container.with_tab(name: "tab1contentpill", label: "Tab 1", active: true)
+    = tab_container.with_tab(name: "tab2contentpill", label: "Tab 2", icon: "fa-otter")
     
-    = tab_container.with_tab_pane(id: "tab1content", active: true) do
+  = render(BuildoutDesignSystem::TabPanes.new()) do | pane |
+    = pane.with_tab_pane(name: "tab1contentpill", active: true) do
       .p-4
         p Tab 1 Content
     
-    = tab_container.with_tab_pane(id: "tab2content") do
+    = pane.with_tab_pane(name: "tab2contentpill") do
       .p-4
         p Tab 2 Content

--- a/test/dummy/test/components/previews/buildout_design_system/tabs_preview/square.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/tabs_preview/square.html.slim
@@ -2,13 +2,14 @@
 = render(BuildoutDesignSystem::Card.new()) do | card |
   
   = render(BuildoutDesignSystem::Tabs.new(variant: "square")) do | tab_container |
-    = tab_container.with_tab(name: "tab1content", label: "Tab 1", active: true)
-    = tab_container.with_tab(name: "tab2content", label: "Tab 2", icon: "fa-otter")
+    = tab_container.with_tab(name: "tab1contentsquare", label: "Tab 1", active: true)
+    = tab_container.with_tab(name: "tab2contentsquare", label: "Tab 2", icon: "fa-otter")
     
-    = tab_container.with_tab_pane(id: "tab1content", active: true) do
+  = render(BuildoutDesignSystem::TabPanes.new()) do | pane |
+    = pane.with_tab_pane(name: "tab1contentsquare", active: true) do
       .p-4
         p Tab 1 Content
     
-    = tab_container.with_tab_pane(id: "tab2content") do
+    = pane.with_tab_pane(name: "tab2contentsquare") do
       .p-4
         p Tab 2 Content

--- a/test/dummy/test/components/previews/buildout_design_system/tabs_preview/vertical.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/tabs_preview/vertical.html.slim
@@ -1,0 +1,14 @@
+= render(BuildoutDesignSystem::Card.new()) do 
+  .d-flex
+    div
+      = render(BuildoutDesignSystem::Tabs.new(variant: "pills", direction: "vertical")) do |tab_container|
+        = tab_container.with_tab(name: "tab1contentver", label: "Tab 1", active: true)
+        = tab_container.with_tab(name: "tab2contentver", label: "Tab 2", icon: "fa-otter")
+    .flex-grow-1
+      = render(BuildoutDesignSystem::TabPanes.new()) do | pane |
+        = pane.with_tab_pane(name: "tab1contentver", active: true) do
+          .p-4
+            p Tab 1 Content
+        = pane.with_tab_pane(name: "tab2contentver") do
+          .p-4
+            p Tab 2 Content


### PR DESCRIPTION
This will allow the Tab Component to be separated in a layout. You can now youse tabs from a different layout to the tab panes and as long as the IDs match, the functionality should still work.

fixes issue #27 