### PR TITLE
Add popover and tooltip previews #14 #13

### DIFF
--- a/app/assets/stylesheets/buildout_design_system/components/popover.scss
+++ b/app/assets/stylesheets/buildout_design_system/components/popover.scss
@@ -1,0 +1,3 @@
+.popover {
+  box-shadow: var(--#{$prefix}popover-box-shadow);
+}

--- a/app/assets/stylesheets/buildout_design_system/config/_light.scss
+++ b/app/assets/stylesheets/buildout_design_system/config/_light.scss
@@ -110,3 +110,9 @@ $modal-content-bg: $card-bg !default;
 
 // Table
 $table-striped-bg: $storm-grey-50 !default;
+
+// --------------------------------------------------
+// POPOVER
+// --------------------------------------------------
+$popover-bg: $card-bg;
+$popover-border-color: $card-bg;

--- a/app/assets/stylesheets/buildout_design_system/config/theme.scss
+++ b/app/assets/stylesheets/buildout_design_system/config/theme.scss
@@ -172,6 +172,11 @@ $nav-tabs-border-width: 0 !default;
 $nav-tabs-link-active-bg: transparent !default;
 
 // --------------------------------------------------
+// POPOVER
+// --------------------------------------------------
+$popover-box-shadow: $box-shadow;
+
+// --------------------------------------------------
 // BADGES
 // --------------------------------------------------
 $badge-padding-x: map-get($spacers, 3) !default; // 12px

--- a/test/dummy/app/assets/javascript/application.js
+++ b/test/dummy/app/assets/javascript/application.js
@@ -1,1 +1,2 @@
+//= require popper
 //= require bootstrap

--- a/test/dummy/test/components/previews/buildout_design_system/popover_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/popover_preview.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class PopoverPreview < ViewComponent::Preview
+    # @!group Popover
+
+    # Popover
+    # -------------------------
+    # Default bootstrap Popover
+    def default; end
+
+    # @!endgroup
+  end
+end

--- a/test/dummy/test/components/previews/buildout_design_system/popover_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/popover_preview/default.html.slim
@@ -1,0 +1,7 @@
+button.btn.btn-secondary#popover-example[
+  data-bs-toggle="popover"
+  data-bs-html="true"
+  data-bs-content="<div><strong>Lorem ipsum</strong> dolor sit amet consectetur adipisicing elit. Corrupti, debitis.</div>"]
+  | This is a button
+javascript:
+  new bootstrap.Popover(document.getElementById("popover-example"))

--- a/test/dummy/test/components/previews/buildout_design_system/tooltip_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/tooltip_preview.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class TooltipPreview < ViewComponent::Preview
+    # @!group Tooltip
+
+    # Tooltip
+    # -------------------------
+    # Default bootstrap tooltip
+    def default; end
+
+    # @!endgroup
+  end
+end

--- a/test/dummy/test/components/previews/buildout_design_system/tooltip_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/tooltip_preview/default.html.slim
@@ -1,0 +1,7 @@
+p
+  ' Lorem ipsum dolor sit
+  a#example> href="#" data-bs-toggle="tooltip" data-bs-title="Default tooltip" consectetur
+  ' amet, adipisicing elit. Quisquam, tempore!
+
+javascript:
+  new bootstrap.Tooltip(document.getElementById("example"))


### PR DESCRIPTION
This commit does the following
1. Updates the popover styling to match the design system
2. Adds preview files for popover and tooltip

Doesn't actually add components for these since they're controlled via javascript