### PR TITLE
input styling and component

### DIFF
--- a/app/assets/stylesheets/buildout_design_system/components/button.scss
+++ b/app/assets/stylesheets/buildout_design_system/components/button.scss
@@ -7,6 +7,7 @@
   font-weight: $font-weight-bold;
   gap: map-get($spacers, 2);
   justify-content: center;
+  height: $button-height;
 
   &.btn-icon {
     padding: map-get($spacers, 2);

--- a/app/assets/stylesheets/buildout_design_system/components/input.scss
+++ b/app/assets/stylesheets/buildout_design_system/components/input.scss
@@ -1,0 +1,91 @@
+input.form-control {
+  height: $input-height;
+
+  &:not(:disabled) {
+    background: $input-bg;
+  }
+
+  &:read-only {
+    background: $input-disabled-bg;
+  }
+
+  &.is-invalid {
+    background-color: $input-invalid-bg-color;
+    border-width: $input-border-width + 1px;
+  }
+}
+
+.input-group {
+  border: $input-border-width solid var(--border-color);
+  border-radius: $input-border-radius;
+  background: $input-group-addon-bg;
+  transition: $input-transition;
+  height: $input-height;
+  --border-color: #{$input-border-color};
+
+  &:has(.is-invalid) {
+    --border-color: #{$input-invalid-border-color};
+    border-width: $input-border-width + 1px;
+    background: $input-invalid-border-color;
+    color: $input-invalid-bg-color;
+
+    &:focus-within {
+      border-color: $input-invalid-border-color;
+      box-shadow: 0 0 0 0.25rem rgba($danger, 0.25);
+    }
+
+    & + .helper-message {
+      color: $input-invalid-helper-color;
+    }
+  }
+
+  &:focus-within {
+    border-color: $input-focus-border-color;
+    box-shadow: 0 0 0 0.25rem rgba($primary, 0.25);
+  }
+
+  input.form-control {
+    border: 0;
+    height: 100%;
+    margin: 0 !important;
+
+    &:focus {
+      box-shadow: none;
+    }
+
+    &:focus:not(.is-invalid) {
+      border-color: $border-color;
+    }
+  }
+
+  > :first-child {
+    border-top-left-radius: calc(#{$input-border-radius} - 1px);
+    border-bottom-left-radius: calc(#{$input-border-radius} - 1px);
+  }
+
+  > :last-child {
+    border-top-right-radius: calc(#{$input-border-radius} - 1px);
+    border-bottom-right-radius: calc(#{$input-border-radius} - 1px);
+  }
+
+  .input-group-text {
+    color: currentColor;
+    border: 0;
+    background: transparent;
+    flex-shrink: 0;
+    min-width: $input-height;
+    padding: 0 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .input-group-text:first-child {
+    border-right: 1px solid var(--border-color);
+  }
+
+  .input-group-text:last-child {
+    margin: 0 !important;
+    border-left: 1px solid var(--border-color);
+  }
+}

--- a/app/assets/stylesheets/buildout_design_system/config/_light.scss
+++ b/app/assets/stylesheets/buildout_design_system/config/_light.scss
@@ -99,9 +99,13 @@ $input-border-color: $border-color !default;
 $input-border-radius: $border-radius !default;
 $input-bg: $white !default;
 $input-color: $body-color !default;
-$input-disabled-bg: $storm-grey-300 !default;
+$input-disabled-bg: $storm-grey-100 !default;
 $input-focus-border-color: $buildout-blue-100 !default;
 $input-group-addon-bg: $storm-grey-100 !default;
+$input-invalid-color: $solid-pink-50 !default;
+$input-invalid-border-color: $solid-pink-400 !default;
+$input-invalid-bg-color: $solid-pink-50 !default;
+$input-invalid-helper-color: $solid-pink-400 !default;
 // Accordion
 $accordion-bg: $card-bg !default;
 $accordion-border-color: $border-color !default;

--- a/app/assets/stylesheets/buildout_design_system/config/theme.scss
+++ b/app/assets/stylesheets/buildout_design_system/config/theme.scss
@@ -143,11 +143,17 @@ $border-width: 1px !default;
 $form-label-font-weight: 700 !default;
 $input-padding-x: $spacer !default; // 16px
 $input-padding-y: map-get($spacers, 2) !default; // 8px
-$input-line-height: 1.2 !default; // close to 22px for 16px font
+$input-line-height: 1.375 !default; // close to 22px for 16px font
 
 $btn-line-height: $input-line-height !default;
 $btn-padding-x: $input-padding-x !default;
 $btn-padding-y: $input-padding-y !default;
+$input-height: 40px !default;
+$button-height: 40px !default;
+$form-feedback-valid-color: $storm-grey-300;
+$form-feedback-invalid-color: $solid-pink-400;
+$form-feedback-icon-valid: none;
+$form-feedback-icon-invalid: none;
 
 // --------------------------------------------------
 // CARDS

--- a/app/components/buildout_design_system/input.html.slim
+++ b/app/components/buildout_design_system/input.html.slim
@@ -1,0 +1,6 @@
+- input_class = "form-control #{@class_name}"
+
+- if @form_context.present?
+  = @form_context.text_field(@field_name, class: input_class, type: "#{@type}", **@attrs)
+- else
+  input class=input_class type="#{@type}" *@attrs

--- a/app/components/buildout_design_system/input.rb
+++ b/app/components/buildout_design_system/input.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class Input < ViewComponent::Base
+    def initialize(form_context: nil, field_name: nil, **attrs)
+      @form_context = form_context
+      @field_name = field_name
+      @class_name = attrs[:class]
+      @attrs = attrs.except(:class, :type)
+      @type = attrs[:type] || "text"
+    end
+  end
+end

--- a/app/components/buildout_design_system/input_wrapper.html.slim
+++ b/app/components/buildout_design_system/input_wrapper.html.slim
@@ -1,0 +1,11 @@
+label.d-flex.flex-column.gap-2 class=@class_name *@attrs
+  - if label?
+    = label
+  span.d-flex.input-group
+    - if prefix?
+      = prefix
+    = input
+    - if suffix?
+      = suffix
+  - if helper_message?
+    = helper_message

--- a/app/components/buildout_design_system/input_wrapper.rb
+++ b/app/components/buildout_design_system/input_wrapper.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class InputWrapper < ViewComponent::Base
+    renders_one :label, "Label"
+    renders_one :prefix, "InputAddon"
+    renders_one :suffix, "InputAddon"
+    renders_one :input, ::BuildoutDesignSystem::Input
+    renders_one :helper_message, "HelperMessage"
+
+    def initialize(**attrs)
+      @class_name = attrs[:class]
+      @attrs = attrs.except(:class)
+    end
+
+    class HelperMessage < ViewComponent::Base
+      attr_reader :attrs, :class_name
+
+      def initialize(**attrs)
+        super()
+        @class_name = attrs[:class]
+        @attrs = attrs.except(:class)
+      end
+
+      def call
+        content_tag(:span, content, class: "d-block helper-message #{class_name}", **attrs)
+      end
+    end
+
+    class Label < ViewComponent::Base
+      attr_reader :attrs, :class_name
+
+      def initialize(**attrs)
+        super()
+        @class_name = attrs[:class]
+        @attrs = attrs.except(:class)
+      end
+
+      def call
+        content_tag(:span, class: "d-flex gap-1 fw-bold") do
+          span_content = content_tag :span, content, class: "fw-bold #{class_name}", **attrs
+          span_content << content_tag(:span, " *", class: "text-danger") if attrs[:required]
+          span_content
+        end
+      end
+    end
+
+    class InputAddon < ViewComponent::Base
+      attr_reader :attrs, :class_name
+
+      def initialize(**attrs)
+        super()
+        @class_name = attrs[:class]
+        @attrs = attrs.except(:class)
+      end
+
+      def call
+        content_tag :span, content, { class: "input-group-text #{class_name}", **attrs }
+      end
+    end
+  end
+end

--- a/test/dummy/test/components/previews/buildout_design_system/input_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/input_preview.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class InputPreview < ViewComponent::Preview
+    # Input
+    # -------------------------
+    # @param type "text"
+    # @param invalid toggle
+    # @param disabled toggle
+    # @param readonly toggle
+    def default(type: "text", disabled: false, invalid: false, readonly: false)
+      render_with_template(locals: {
+        type: type,
+        readonly: readonly,
+        disabled: disabled,
+        invalid: invalid
+      })
+    end
+
+    # Input
+    # -------------------------
+    # @param type "text"
+    # @param invalid toggle
+    # @param disabled toggle
+    # @param readonly toggle
+    def with_form(type: "text", disabled: false, invalid: false, readonly: false)
+      render_with_template(locals: {
+        type: type,
+        readonly: readonly,
+        disabled: disabled,
+        invalid: invalid
+      })
+    end
+  end
+end

--- a/test/dummy/test/components/previews/buildout_design_system/input_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/input_preview/default.html.slim
@@ -1,0 +1,1 @@
+= render(BuildoutDesignSystem::Input.new(type: type, class: "#{invalid ? "is-invalid" : ""}", disabled: disabled, readonly: readonly))

--- a/test/dummy/test/components/previews/buildout_design_system/input_preview/with_form.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/input_preview/with_form.html.slim
@@ -1,0 +1,12 @@
+= form_with url: "/", id: "test-form" do |form|
+  = render(BuildoutDesignSystem::Input.new(type: type, class: "#{invalid ? "is-invalid" : ""}", disabled: disabled, readonly: readonly, form_context: form, field_name: :test))
+  button Send me
+
+javascript:
+  const form = document.getElementById("test-form");
+  form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const formData = new FormData(form);
+      const dataForAlert = [...formData].map(formField => `${formField[0]}: ${formField[1]}`).join("\n")
+      alert(dataForAlert)
+  });

--- a/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class InputWrapperPreview < ViewComponent::Preview
+    # Input
+    # -------------------------
+    # Input wrapper to help with formatting a prefix or suffix addon to the input, a label, and a helper message.
+    # @param type "text"
+    # @param label "label"
+    # @param required toggle
+    # @param invalid toggle
+    # @param disabled toggle
+    # @param readonly toggle
+    # @param helper_message "text"
+    def with_prefix(type: "text", label: "test", required: false, disabled: false, invalid: false, helper_message: "helpful message", readonly: false)
+      render_with_template(locals: {
+        type: type,
+        label: label,
+        required: required,
+        disabled: disabled,
+        invalid: invalid,
+        helper_message: helper_message,
+        readonly: readonly
+      })
+    end
+
+    # Input
+    # -------------------------
+    # Input wrapper to help with formatting a prefix or suffix addon to the input, a label, and a helper message.
+    # @param type "text"
+    # @param label "label"
+    # @param required toggle
+    # @param invalid toggle
+    # @param disabled toggle
+    # @param readonly toggle
+    # @param helper_message "text"
+    def with_prefix_and_suffix(type: "text", label: "test", required: false, disabled: false, invalid: false, helper_message: "helpful message", readonly: false)
+      render_with_template(locals: {
+        type: type,
+        label: label,
+        required: required,
+        disabled: disabled,
+        invalid: invalid,
+        helper_message: helper_message,
+        readonly: readonly
+      })
+    end
+
+    # Input
+    # -------------------------
+    # Input wrapper to help with formatting a prefix or suffix addon to the input, a label, and a helper message.
+    # @param type "text"
+    # @param label "label"
+    # @param required toggle
+    # @param invalid toggle
+    # @param disabled toggle
+    # @param readonly toggle
+    # @param helper_message "text"
+    def with_suffix(type: "text", label: "test", required: false, disabled: false, invalid: false, helper_message: "helpful message", readonly: false)
+      render_with_template(locals: {
+        type: type,
+        label: label,
+        required: required,
+        disabled: disabled,
+        invalid: invalid,
+        helper_message: helper_message,
+        readonly: readonly
+      })
+    end
+  end
+end

--- a/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview/with_prefix.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview/with_prefix.html.slim
@@ -1,0 +1,8 @@
+= render(BuildoutDesignSystem::InputWrapper.new) do |input_wrapper|
+  - input_wrapper.with_input(disabled: disabled, class: "#{invalid ? "is-invalid" : ""}", readonly: readonly, required: required, type: type)
+  - input_wrapper.with_prefix do
+    i.fas.fa-search
+  - if label
+    - input_wrapper.with_label(required: required) { label }
+  - if helper_message
+    - input_wrapper.with_helper_message { helper_message }

--- a/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview/with_prefix_and_suffix.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview/with_prefix_and_suffix.html.slim
@@ -1,0 +1,10 @@
+= render(BuildoutDesignSystem::InputWrapper.new) do |input_wrapper|
+  - input_wrapper.with_input(disabled: disabled, class: "#{invalid ? "is-invalid" : ""}", readonly: readonly, required: required, type: type)
+  - input_wrapper.with_prefix do
+    i.fas.fa-search
+  - input_wrapper.with_suffix do
+    span 0.00
+  - if label
+    - input_wrapper.with_label(required: required) { label }
+  - if helper_message
+    - input_wrapper.with_helper_message { helper_message }

--- a/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview/with_suffix.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/input_wrapper_preview/with_suffix.html.slim
@@ -1,0 +1,8 @@
+= render(BuildoutDesignSystem::InputWrapper.new) do |input_wrapper|
+  - input_wrapper.with_input(disabled: disabled, class: "#{invalid ? "is-invalid" : ""}", readonly: readonly, required: required, type: type)
+  - input_wrapper.with_suffix do
+    span 0.00
+  - if label
+    - input_wrapper.with_label(required: required) { label }
+  - if helper_message
+    - input_wrapper.with_helper_message { helper_message }


### PR DESCRIPTION
input field that allows for use of passing in a form and the form field associated with it!

### Notes
- it is wrapped in a label
- its always rendered in an input-group
  - this is just for ease of consistency, the styling is the same wether or not its wrapped in an input-group
  - if we were to use just the bootstrap input-group, this would be fine, but bootstraps input group highlights only the input field when focused, where this highlights what looks like the full input (so including icons or anything)