### PR TITLE
Accordion - fix @open behavior

### DIFF
--- a/app/components/buildout_design_system/accordion/accordion_item.html.slim
+++ b/app/components/buildout_design_system/accordion/accordion_item.html.slim
@@ -1,12 +1,12 @@
 .accordion-item
   div.accordion-header
-    button.accordion-button.collapsed[type="button" data-bs-toggle="collapse" data-bs-target="##{@id}"]
+    button.accordion-button class=("collapsed" unless @open) type="button" data-bs-toggle="collapse" data-bs-target="##{@id}"
       .flex-grow-1
         - if @icon
           i.accordion-icon.me-4 class=@icon
         = @title
       - actions.each do |action|
         div= action
-  .accordion-collapse id=@id class=("collapse" unless @open)
+  .accordion-collapse id=@id class=(@open ? "show" : "collapse") aria-labelledby=@id
     .accordion-body
       = content


### PR DESCRIPTION
this wasn't working properly on first action for accordions with `open: true`

## BEFORE
![accordion-before-fix](https://github.com/buildoutinc/buildout_design_system/assets/19396517/47567738-f78d-4ad8-8283-4a6c4633d533)

## AFTER
![accordion-after-fix](https://github.com/buildoutinc/buildout_design_system/assets/19396517/d1a3e3c8-b30a-4803-845b-8bf2ba48058a)
