### PR TITLE
[FIX] Missing splat attributes from components

### DIFF
--- a/app/components/buildout_design_system/accordion.rb
+++ b/app/components/buildout_design_system/accordion.rb
@@ -5,9 +5,11 @@ module BuildoutDesignSystem
     renders_many :accordion_items, ::BuildoutDesignSystem::Accordion::AccordionItem
 
     def initialize( # rubocop:disable Lint/MissingSuper
-      variant: "primary"
+      variant: "primary",
+      **attrs
     )
       @variant = variant
+      @attrs = attrs
     end
   end
 end

--- a/app/components/buildout_design_system/accordion/accordion.html.slim
+++ b/app/components/buildout_design_system/accordion/accordion.html.slim
@@ -1,3 +1,3 @@
-.accordion class="accordion-#{@variant}" id=@id
+.accordion class="accordion-#{@variant}" *@attrs 
   - accordion_items.each do |accordion_item|
     = accordion_item

--- a/app/components/buildout_design_system/accordion/accordion_item.html.slim
+++ b/app/components/buildout_design_system/accordion/accordion_item.html.slim
@@ -1,4 +1,4 @@
-.accordion-item
+.accordion-item *@attrs
   div.accordion-header
     button.accordion-button class=("collapsed" unless @open) type="button" data-bs-toggle="collapse" data-bs-target="##{@id}"
       .flex-grow-1

--- a/app/components/buildout_design_system/accordion/accordion_item.rb
+++ b/app/components/buildout_design_system/accordion/accordion_item.rb
@@ -7,11 +7,12 @@ module BuildoutDesignSystem
 
       renders_many :actions
 
-      def initialize(title: nil, icon: nil, open: false) # rubocop:disable Lint/MissingSuper
+      def initialize(title: nil, icon: nil, open: false, **attrs) # rubocop:disable Lint/MissingSuper
         @title = title
         @icon = icon
         @id = (0...8).map { rand(65..90).chr }.join
         @open = open
+        @attrs = attrs
       end
     end
   end

--- a/app/components/buildout_design_system/alert.html.slim
+++ b/app/components/buildout_design_system/alert.html.slim
@@ -1,4 +1,4 @@
-.alert.d-flex.align-items-start.gap-2 class="alert-#{@status} #{@class_name} #{@dismissable ? "alert-dismissable" : ""}" role="alert"
+.alert.d-flex.align-items-start.gap-2 class="alert-#{@status} #{@class_name} #{@dismissable ? "alert-dismissable" : ""}" role="alert" *@attrs
   i.fa-solid.fa-fw.mt-1 class="#{@icon}"
   .alert-content.flex-grow-1
     - if @title.present?

--- a/app/components/buildout_design_system/alert.rb
+++ b/app/components/buildout_design_system/alert.rb
@@ -21,13 +21,15 @@ module BuildoutDesignSystem
       icon: nil,
       title: nil,
       class_name: "",
-      dismissable: false
+      dismissable: false,
+      **attrs
     )
       @status = STATUSES.fetch(status.to_sym) || "info"
       @icon =  icon || DEFAULT_ICONS.fetch(status.to_sym)
       @title = title
       @class_name = class_name
       @dismissable = dismissable
+      @attrs = attrs
     end
   end
 end

--- a/app/components/buildout_design_system/card.html.slim
+++ b/app/components/buildout_design_system/card.html.slim
@@ -2,8 +2,7 @@
   - if image
     = image
   - if header?
-    .card-header
-      = header
+    = header
   .card-body
     - if title?
         = title

--- a/app/components/buildout_design_system/card.rb
+++ b/app/components/buildout_design_system/card.rb
@@ -14,13 +14,16 @@ module BuildoutDesignSystem
     class CardHeaderComponent < ViewComponent::Base
       attr_reader :class_name
 
-      def initialize(class_name: "")
+      def initialize(class_name: "", **attrs)
         super()
         @class_name = class_name
+        @attrs = attrs
       end
 
       def call
-        content_tag :span, content, { class: class_name }
+        content_tag :div, { class: "card-header", **@attrs } do
+          content_tag :div, content, class_name.present? ? { class: class_name } : nil
+        end
       end
     end
 
@@ -41,27 +44,29 @@ module BuildoutDesignSystem
     class CardTitleComponent < ViewComponent::Base
       attr_reader :class_name
 
-      def initialize(class_name: "", title: "")
+      def initialize(class_name: "", title: "", **attrs)
         super()
         @class_name = class_name
         @title = title
+        @attrs = attrs
       end
 
       def call
-        content_tag :h5, @title, { class: "card-title #{class_name}" }
+        content_tag :h5, @title, { class: "card-title #{class_name}", **@attrs}
       end
     end
 
     class CardFooterComponent < ViewComponent::Base
       attr_reader :class_name
 
-      def initialize(class_name: "")
+      def initialize(class_name: "", **attrs)
         super()
         @class_name = class_name
+        @attrs = attrs
       end
 
       def call
-        content_tag :div, content, { class: "card-footer d-flex gap-2 #{class_name}" }
+        content_tag :div, content, { class: "card-footer d-flex gap-2 #{class_name}", **@attrs }
       end
     end
   end

--- a/app/components/buildout_design_system/empty_state.html.slim
+++ b/app/components/buildout_design_system/empty_state.html.slim
@@ -1,4 +1,4 @@
-.p-4.text-center
+.p-4.text-center *@attrs
   - if @icon
     .my-4
       span.fa-stack.fa-xl

--- a/app/components/buildout_design_system/empty_state.rb
+++ b/app/components/buildout_design_system/empty_state.rb
@@ -5,11 +5,13 @@ module BuildoutDesignSystem
     def initialize( # rubocop:disable Lint/MissingSuper
       title:,
       text: nil,
-      icon: "fa-exclamation"
+      icon: "fa-exclamation",
+      **attrs
     )
       @title = title
       @icon = icon
       @text = text
+      @attrs = attrs
     end
   end
 end

--- a/app/components/buildout_design_system/modal/modal_header.html.slim
+++ b/app/components/buildout_design_system/modal/modal_header.html.slim
@@ -1,4 +1,4 @@
-.modal-header class="#{@class_name}"
+.modal-header class="#{@class_name}" *@attrs
   - if @title
     h5.modal-title = @title
   - else 

--- a/app/components/buildout_design_system/modal/modal_header.rb
+++ b/app/components/buildout_design_system/modal/modal_header.rb
@@ -4,10 +4,11 @@ module BuildoutDesignSystem
   class Modal
     class ModalHeader < ViewComponent::Base
 
-      def initialize(class_name: "", title: nil)
+      def initialize(class_name: "", title: nil, **attrs)
         super()
         @class_name = class_name
         @title = title
+        @attrs = attrs
       end
 
     end

--- a/app/components/buildout_design_system/off_canvas/off_canvas_header.html.slim
+++ b/app/components/buildout_design_system/off_canvas/off_canvas_header.html.slim
@@ -1,4 +1,4 @@
-.offcanvas-header
+.offcanvas-header *@attrs
   h5.offcanvas-title = @title
   = render(BuildoutDesignSystem::Button.new({ variant: "secondary", style: "text" }, data: { "bs-dismiss": "offcanvas"}, "aria-label": "Close")) do 
     i.fas.fa-times

--- a/app/components/buildout_design_system/pagination.html.slim
+++ b/app/components/buildout_design_system/pagination.html.slim
@@ -1,5 +1,5 @@
 - pages = @options[:total] && @options[:per_page] ? (@options[:total] / @options[:per_page].to_f).ceil : 1
-nav.pagination-container class="#{@align}" aria-label="page navigation"
+nav.pagination-container class="#{@align}" aria-label="page navigation" *@attrs
   ul.pagination
     - if @options[:show_first_last]
       li.page-item.first class="#{@options[:current_page] == 1 ? 'disabled' : ''}"

--- a/app/components/buildout_design_system/progress_bar.html.slim
+++ b/app/components/buildout_design_system/progress_bar.html.slim
@@ -1,4 +1,4 @@
-.progress-container class="#{@variant}" 
+.progress-container class="#{@variant}" *@attrs
   - if @steps.present?
     - @steps.each do | step, index |
       .progress-step

--- a/app/components/buildout_design_system/tab.html.slim
+++ b/app/components/buildout_design_system/tab.html.slim
@@ -4,7 +4,11 @@ li.nav-item
     data-bs-target=("##{@name}" if @name.present?)
     data-bs-toggle="tab"
     href="#"
+    *@attrs
   )
     - if @icon.present?
       i.fa.fa-solid.me-2.fa-xs class="#{@icon}"
-    span.text-container= @label
+    - if @label.present? && content.nil?
+      span.text-container= @label
+    - else 
+      = content

--- a/app/components/buildout_design_system/tab_pane.html.slim
+++ b/app/components/buildout_design_system/tab_pane.html.slim
@@ -1,2 +1,2 @@
-.tab-pane class=[@class_name, ("active" if @active)] id=@name
+.tab-pane class=[@class_name, ("active" if @active)] id=@name *@attrs
   = content

--- a/app/components/buildout_design_system/tab_pane.rb
+++ b/app/components/buildout_design_system/tab_pane.rb
@@ -3,11 +3,12 @@
 module BuildoutDesignSystem
   class TabPane < ViewComponent::Base
     attr_reader :class_name, :active, :name
-    def initialize(class_name: "", active: false, name: nil)
+    def initialize(class_name: "", active: false, name: nil, **attrs)
       super()
       @class_name = class_name
       @active = active
       @name = name
+      @attrs = attrs.except(:id)
     end
   end
 end

--- a/app/components/buildout_design_system/tab_panes.html.slim
+++ b/app/components/buildout_design_system/tab_panes.html.slim
@@ -1,4 +1,4 @@
-.tab-content class=@class_name
+.tab-content class=@class_name *@attrs
   - if tab_panes?
     - tab_panes.each do | tab_pane |
       = tab_pane

--- a/app/components/buildout_design_system/tabs.html.slim
+++ b/app/components/buildout_design_system/tabs.html.slim
@@ -1,4 +1,4 @@
-ul.nav class="#{@variant} #{@direction}" role="tablist"
+ul.nav class="#{@variant} #{@direction}" role="tablist" *@attrs
   - if tabs?
     - tabs.each do | tab |
       = tab

--- a/lib/buildout_design_system/version.rb
+++ b/lib/buildout_design_system/version.rb
@@ -1,3 +1,3 @@
 module BuildoutDesignSystem
-  VERSION = "0.1.11"
+  VERSION = "0.1.12"
 end

--- a/test/dummy/test/components/previews/buildout_design_system/card_preview/with_header.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/card_preview/with_header.html.slim
@@ -1,5 +1,5 @@
 = render(BuildoutDesignSystem::Card.new()) do  |card|
-  - card.with_header do
+  - card.with_header(id: "fancyHeaderID") do
     = header
 
   = content

--- a/test/dummy/test/components/previews/buildout_design_system/card_preview/with_image.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/card_preview/with_image.html.slim
@@ -5,7 +5,7 @@
 
   = content
 
-  - card.with_footer do
+  - card.with_footer(id: "fancyFooterID") do
     = render(BuildoutDesignSystem::Button.new({variant: "primary"})) do
       | Click Me
     = render(BuildoutDesignSystem::Button.new({ variant: "secondary"})) do 

--- a/test/dummy/test/components/previews/buildout_design_system/modal_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/modal_preview/default.html.slim
@@ -3,7 +3,7 @@
 
 
 = render(BuildoutDesignSystem::Modal.new(class_name: "", size: size, id: "exampleModal", centered: centered)) do |modal|
-  - modal.with_header(title: "Modal Title")
+  - modal.with_header(title: "Modal Title", id: "exampleModalId")
   - modal.with_body do
     | Modal Body
   - modal.with_footer do

--- a/test/dummy/test/components/previews/buildout_design_system/tabs_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/tabs_preview.rb
@@ -14,5 +14,7 @@ module BuildoutDesignSystem
     def vertical; end
 
     def text; end
+
+    def block; end
   end
 end

--- a/test/dummy/test/components/previews/buildout_design_system/tabs_preview/block.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/tabs_preview/block.html.slim
@@ -1,0 +1,16 @@
+
+= render(BuildoutDesignSystem::Card.new()) do | card |
+  
+  = render(BuildoutDesignSystem::Tabs.new()) do | tab_container |
+    = tab_container.with_tab(name: "tab1contentdef", active: true, id: "fancyID") do 
+      .text-primary This is Tab!
+    = tab_container.with_tab(name: "tab2contentdef", label: "Tab 2", icon: "fa-otter")
+
+  = render(BuildoutDesignSystem::TabPanes.new()) do | pane |
+    = pane.with_tab_pane(name: "tab1contentdef", active: true) do
+      .p-4
+        p Tab 1 Content
+    
+    = pane.with_tab_pane(name: "tab2contentdef") do
+      .p-4
+        p Tab 2 Content


### PR DESCRIPTION
This adds the attributes splat operators to the missing templates, so we can pass more attributes to the components if needed.