### PR TITLE
Fix error when SimpleForm is not present

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildout_design_system (0.1.11)
+    buildout_design_system (0.1.13)
       rails (>= 6.0)
       view_component (~> 3.5)
 
@@ -141,14 +141,14 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    net-imap (0.4.10)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.0)
     nokogiri (1.16.0-arm64-darwin)

--- a/app/inputs/toggle_input.rb
+++ b/app/inputs/toggle_input.rb
@@ -1,8 +1,12 @@
-class ToggleInput < SimpleForm::Inputs::Base
-  def input(wrapper_options)
-    merged_input_options = merge_wrapper_options(options.except(:as, :label), wrapper_options)
-    template.render(
-      html: ActionController::Base.renderer.render(BuildoutDesignSystem::Toggle.new(form_context: @builder, field_name: attribute_name, **merged_input_options))
-    )
+if defined?(SimpleForm)
+  class ToggleInput < SimpleForm::Inputs::Base
+    def input(wrapper_options)
+      merged_input_options = merge_wrapper_options(options.except(:as, :label), wrapper_options)
+      template.render(
+        html: ActionController::Base.renderer.render(BuildoutDesignSystem::Toggle.new(form_context: @builder, field_name: attribute_name, **merged_input_options))
+      )
+    end
   end
+else
+  class ToggleInput; end
 end

--- a/lib/buildout_design_system/version.rb
+++ b/lib/buildout_design_system/version.rb
@@ -1,3 +1,3 @@
 module BuildoutDesignSystem
-  VERSION = "0.1.12"
+  VERSION = "0.1.13"
 end


### PR DESCRIPTION
The simple form gem is not a dependency so when a project like Clarity is using the design system, it was crashing because it did not have SimpleForm defined