### PR TITLE
Added ability to override card body classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [1.0.0] - 2024-07-01
+### Breaking Changes
+- Cards now require a `- card.with_body do` for the content. This allows overriding the classes
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildout_design_system (0.1.13)
+    buildout_design_system (1.0.0)
       rails (>= 6.0)
       view_component (~> 3.5)
 
@@ -153,6 +153,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.0-x86_64-darwin)
+      racc (~> 1.4)
     popper_js (2.11.8)
     psych (5.1.2)
       stringio
@@ -251,6 +253,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-21
 
 DEPENDENCIES
   actioncable

--- a/app/components/buildout_design_system/card.html.slim
+++ b/app/components/buildout_design_system/card.html.slim
@@ -3,9 +3,10 @@
     = image
   - if header?
     = header
-  .card-body
+  = content
+  - if body?
     - if title?
         = title
-    = content
+    = body
   - if footer?
     = footer

--- a/app/components/buildout_design_system/card.html.slim
+++ b/app/components/buildout_design_system/card.html.slim
@@ -5,8 +5,6 @@
     = header
   = content
   - if body?
-    - if title?
-        = title
     = body
   - if footer?
     = footer

--- a/app/components/buildout_design_system/card.rb
+++ b/app/components/buildout_design_system/card.rb
@@ -1,10 +1,9 @@
 module BuildoutDesignSystem
   class Card < ViewComponent::Base
-    renders_one :header, "CardHeaderComponent"
-    renders_one :image, "CardImageComponent"
-    renders_one :title, "CardTitleComponent"
-    renders_one :footer, "CardFooterComponent"
-    renders_one :body, "CardBodyComponent"
+    renders_one :header, "CardHeader"
+    renders_one :image, "CardImage"
+    renders_one :footer, "CardFooter"
+    renders_one :body, CardBody
 
     def initialize(class_name: "", **attrs)
       super(**attrs)
@@ -12,7 +11,7 @@ module BuildoutDesignSystem
       @attrs = attrs
     end
 
-    class CardHeaderComponent < ViewComponent::Base
+    class CardHeader < ViewComponent::Base
       attr_reader :class_name
 
       def initialize(class_name: "", **attrs)
@@ -28,7 +27,7 @@ module BuildoutDesignSystem
       end
     end
 
-    class CardImageComponent < ViewComponent::Base
+    class CardImage < ViewComponent::Base
       attr_reader :image_url, :class_name
 
       def initialize(image_url: "", class_name: "")
@@ -42,22 +41,7 @@ module BuildoutDesignSystem
       end
     end
 
-    class CardTitleComponent < ViewComponent::Base
-      attr_reader :class_name
-
-      def initialize(class_name: "", title: "", **attrs)
-        super()
-        @class_name = class_name
-        @title = title
-        @attrs = attrs
-      end
-
-      def call
-        content_tag :h5, @title, { class: "card-title #{class_name}", **@attrs}
-      end
-    end
-
-    class CardFooterComponent < ViewComponent::Base
+    class CardFooter < ViewComponent::Base
       attr_reader :class_name
 
       def initialize(class_name: "", **attrs)
@@ -68,20 +52,6 @@ module BuildoutDesignSystem
 
       def call
         content_tag :div, content, { class: "card-footer d-flex gap-2 #{class_name}", **@attrs }
-      end
-    end
-
-    class CardBodyComponent < ViewComponent::Base
-      attr_reader :class_name
-
-      def initialize(class_name: "", **attrs)
-        super()
-        @class_name = class_name
-        @attrs = attrs
-      end
-
-      def call
-        content_tag :div, content, { class: "card-body #{class_name}", **@attrs }
       end
     end
   end

--- a/app/components/buildout_design_system/card.rb
+++ b/app/components/buildout_design_system/card.rb
@@ -4,6 +4,7 @@ module BuildoutDesignSystem
     renders_one :image, "CardImageComponent"
     renders_one :title, "CardTitleComponent"
     renders_one :footer, "CardFooterComponent"
+    renders_one :body, "CardBodyComponent"
 
     def initialize(class_name: "", **attrs)
       super(**attrs)
@@ -67,6 +68,20 @@ module BuildoutDesignSystem
 
       def call
         content_tag :div, content, { class: "card-footer d-flex gap-2 #{class_name}", **@attrs }
+      end
+    end
+
+    class CardBodyComponent < ViewComponent::Base
+      attr_reader :class_name
+
+      def initialize(class_name: "", **attrs)
+        super()
+        @class_name = class_name
+        @attrs = attrs
+      end
+
+      def call
+        content_tag :div, content, { class: "card-body #{class_name}", **@attrs }
       end
     end
   end

--- a/app/components/buildout_design_system/card/card_body.html.slim
+++ b/app/components/buildout_design_system/card/card_body.html.slim
@@ -1,0 +1,4 @@
+.card-body class="#{@class_name}" *@attrs
+  - if title?
+    = title
+  = content

--- a/app/components/buildout_design_system/card/card_body.rb
+++ b/app/components/buildout_design_system/card/card_body.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class Card
+    class CardBody < ViewComponent::Base
+      renders_one :title, CardTitle
+
+      attr_reader :class_name
+
+      def initialize(class_name: "", **attrs)
+        super()
+        @class_name = class_name
+        @attrs = attrs
+      end
+    end
+  end
+end

--- a/app/components/buildout_design_system/card/card_title.rb
+++ b/app/components/buildout_design_system/card/card_title.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BuildoutDesignSystem
+  class Card
+    class CardTitle < ViewComponent::Base
+      attr_reader :class_name
+
+      def initialize(class_name: "", title: "", **attrs)
+        super()
+        @class_name = class_name
+        @title = title
+        @attrs = attrs
+      end
+
+      def call
+        content_tag :h5, @title, { class: "card-title #{class_name}", **@attrs}
+      end
+    end
+  end
+end

--- a/lib/buildout_design_system/version.rb
+++ b/lib/buildout_design_system/version.rb
@@ -1,3 +1,3 @@
 module BuildoutDesignSystem
-  VERSION = "0.1.13"
+  VERSION = "1.0.0"
 end

--- a/test/dummy/test/components/previews/buildout_design_system/card_preview.rb
+++ b/test/dummy/test/components/previews/buildout_design_system/card_preview.rb
@@ -6,23 +6,23 @@ module BuildoutDesignSystem
     # -------------------------
     # Cards provide a small section for information.
     #
-    # @param content  textarea "Card Text Body Content"
-    def default(content: "Hello World!")
+    # @param body  textarea "Card Text Body Content"
+    def default(body: "Hello World!")
       render_with_template(locals: {
-        content: content
+        body: body
       })
     end
 
-    def with_header(content: "Hello World!", header: "Header")
+    def with_header(body: "Hello World!", header: "Header")
       render_with_template(locals: {
-        content: content,
+        body: body,
         header: header
       })
     end
 
-    def with_image(content: "Hello World!", title: "Card Title", image_url: "https://picsum.photos/200/200")
+    def with_image(body: "Hello World!", title: "Card Title", image_url: "https://picsum.photos/200/200")
       render_with_template(locals: {
-        content: content,
+        body: body,
         title: title,
         image_url: image_url
       })

--- a/test/dummy/test/components/previews/buildout_design_system/card_preview/default.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/card_preview/default.html.slim
@@ -1,2 +1,3 @@
-= render(BuildoutDesignSystem::Card.new()) do 
-  = content
+= render(BuildoutDesignSystem::Card.new()) do |card|
+  - card.with_body do
+    = body

--- a/test/dummy/test/components/previews/buildout_design_system/card_preview/with_header.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/card_preview/with_header.html.slim
@@ -1,5 +1,3 @@
 = render(BuildoutDesignSystem::Card.new()) do  |card|
   - card.with_header(id: "fancyHeaderID") do
     = header
-
-  = content

--- a/test/dummy/test/components/previews/buildout_design_system/card_preview/with_image.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/card_preview/with_image.html.slim
@@ -1,12 +1,13 @@
 = render(BuildoutDesignSystem::Card.new()) do  |card|
   - card.with_image(image_url: image_url)
 
-  - card.with_title(title: title)
+  - card.with_title(title: title, class_name: "p-4")
 
-  = content
+  - card.with_body() do
+    = body
 
   - card.with_footer(id: "fancyFooterID") do
     = render(BuildoutDesignSystem::Button.new({variant: "primary"})) do
       | Click Me
     = render(BuildoutDesignSystem::Button.new({ variant: "secondary"})) do 
-      | Click Me Too 
+      | Click Me Too

--- a/test/dummy/test/components/previews/buildout_design_system/card_preview/with_image.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/card_preview/with_image.html.slim
@@ -1,9 +1,10 @@
 = render(BuildoutDesignSystem::Card.new()) do  |card|
   - card.with_image(image_url: image_url)
 
-  - card.with_title(title: title, class_name: "p-4")
+  / - card.with_title(title: title, class_name: "p-4")
 
-  - card.with_body() do
+  - card.with_body do | card_body |
+    - card_body.with_title(title: "Card Title")
     = body
 
   - card.with_footer(id: "fancyFooterID") do


### PR DESCRIPTION
We need to be able to do this so we can use the design system to add tables inside cards. The way it currently works we would have extra padding around a table when we don't want it.

Bumped up the version to 1.0.0 because this is a breaking change (changing class_name to container_class). I currently don't see anyony using the Card component but would rather follow convention