### PR TITLE
New Shadows

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "arrowParens": "always",
+  "endOfLine": "auto",
+  "printWidth": 200
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildout_design_system (1.1.2)
+    buildout_design_system (1.1.3)
       rails (>= 6.0)
       view_component (~> 3.5)
 
@@ -141,7 +141,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    net-imap (0.4.14)
+    net-imap (0.4.16)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/assets/stylesheets/buildout_design_system/config/_utilities.scss
+++ b/app/assets/stylesheets/buildout_design_system/config/_utilities.scss
@@ -30,4 +30,16 @@ $custom-utils: (
       12: 12,
     )
   ),
+  "shadow": (
+    property: box-shadow,
+    class: shadow,
+    values: (
+      null: $box-shadow,
+      sm: $box-shadow-sm,
+      md: $box-shadow-md,
+      lg: $box-shadow-lg,
+      xl: $box-shadow-xl,
+      2xl: $box-shadow-2xl,
+    )
+  )
 );

--- a/app/assets/stylesheets/buildout_design_system/config/theme.scss
+++ b/app/assets/stylesheets/buildout_design_system/config/theme.scss
@@ -1,5 +1,5 @@
 @import "colors";
-@import "utilities";
+
 
 // --------------------------------------------------
 // FILE DESCRIPTION
@@ -13,7 +13,6 @@
 // CONFIGURATION
 // --------------------------------------------------
 $prefix: "ds-" !default;
-$utilities: $custom-utils !default;
 $enable-dark-mode: false !default;
 $link-decoration: none !default;
 
@@ -27,7 +26,7 @@ $font-size-sm: $font-size-base * 0.875 !default; // 14px
 
 $font-weight-light: 300 !default;
 $font-weight-normal: 400 !default;
-$font-weight-bold:600 !default;
+$font-weight-bold: 600 !default;
 $font-weight-bolder: 700 !default;
 
 $h1-font-size: $font-size-base * 2.986 !default;
@@ -59,17 +58,17 @@ $line-height: 137.5% !default; // close to 22px for 16px font
 $spacer: 1rem !default; // 16px Base
 $spacers: (
   0: 0,
-  "0-5": ($spacer * 0.125), // 2px
-  1: ($spacer * 0.25), // 4px
-  2: ($spacer * 0.5), // 8px
-  3: ($spacer * 0.75), // 12px
+  "0-5": $spacer * 0.125, // 2px
+  1: $spacer * 0.25, // 4px
+  2: $spacer * 0.5, // 8px
+  3: $spacer * 0.75, // 12px
   4: $spacer, // 16px
-  5: ($spacer * 1.25), // 20px
-  6: ($spacer * 1.5), // 24px
-  7: ($spacer * 1.75), // 28px
-  8: ($spacer * 2), // 32px
-  9: ($spacer * 2.25), // 36px
-  10: ($spacer * 2.5), // 40px
+  5: $spacer * 1.25, // 20px
+  6: $spacer * 1.5, // 24px
+  7: $spacer * 1.75, // 28px
+  8: $spacer * 2, // 32px
+  9: $spacer * 2.25, // 36px
+  10: $spacer * 2.5, // 40px
 ) !default;
 
 // --------------------------------------------------
@@ -81,18 +80,26 @@ $grid-columns: 12 !default;
 $grid-gutter-width: map-get($spacers, 6) !default;
 $gutters: $spacers !default;
 
-
 // --------------------------------------------------
 // SHADOWS
 // NOTE: This requires some review as it is recommended that shadows
 // should be reflective of the color of the element that is emitting the shadow.
 // --------------------------------------------------
-$box-shadow: 0 0.25rem 0.5rem rgba($black, 0.25) !default;
-$box-shadow-xs: 0 1px 0 0 rgba($black, 0.25) !default;
-$box-shadow-sm: 0 0.125rem 0.25rem rgba($black, 0.25) !default;
-$box-shadow-md: 0 0.5rem 1rem rgba($black, 0.25) !default;
-$box-shadow-lg: 0 0.75rem 1.5rem rgba($black, 0.25) !default;
-$box-shadow-xl: 0 1rem 2rem rgba($black, 0.35) !default;
+$box-shadow-sm:
+  0px 1px 3px 0px rgba($black, 0.1),
+  0px 1px 2px -1px rgba($black, 0.1) !default;
+$box-shadow-xs: $box-shadow-sm !default;
+$box-shadow-md:
+  0px 4px 6px -1px rgba($black, 0.1),
+  0px 2px 4px -2px rgba($black, 0.1) !default;
+$box-shadow: $box-shadow-md !default;
+$box-shadow-lg:
+  0px 10px 15px -3px rgba($black, 0.1),
+  0px 4px 6px -4px rgba($black, 0.1) !default;
+$box-shadow-xl:
+  0px 20px 25px -5px rgba($black, 0.1),
+  0px 8px 10px -6px rgba($black, 0.1) !default;
+$box-shadow-2xl: 0px 25px 50px -12px rgba($black, 0.25) !default;
 $box-shadow-inset: inset $box-shadow !default;
 
 // --------------------------------------------------
@@ -129,7 +136,6 @@ $xlong: 700ms !default;
 $xlong2: 800ms !default;
 $xlong3: 900ms !default;
 $xlong4: 1000ms !default;
-
 
 // --------------------------------------------------
 // BORDERS
@@ -199,9 +205,15 @@ $popover-box-shadow: $box-shadow;
 $badge-padding-x: map-get($spacers, 3) !default; // 12px
 $badge-padding-y: map-get($spacers, 1) !default; // 4px
 
-
 // --------------------------------------------------
 // TABLES
 // --------------------------------------------------
 $table-bg: none !default;
 $table-border-width: 0 !default;
+
+
+// --------------------------------------------------
+// UTILITIES
+// --------------------------------------------------
+@import "utilities";
+$utilities: $custom-utils !default;

--- a/lib/buildout_design_system/version.rb
+++ b/lib/buildout_design_system/version.rb
@@ -1,3 +1,3 @@
 module BuildoutDesignSystem
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end


### PR DESCRIPTION
# New Shadows
This  is a non-breaking update will add a new set of styles for the current shadows of bootstrap and make them slightly software and more natural.

### Notes
This should not affect any design, it will just soften some shadows. No classes were removed.

### New
This adds a new utility class option that expands the current bootstrap offering by giving you. You can use these as additional classes on any component.
* `shadow` - default shadow (`shadow-md` is default)
* `shadow-sm` - small shadow
* `shadow-md` - medium
* `shadow-lg` - large
* `shadow-xl` - x-large
* `shadow-2xl` - 2x-large 