### PR TITLE
Fixing Sticky Table Layout due to Chrome's Update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildout_design_system (1.2.0)
+    buildout_design_system (1.2.1)
       rails (>= 6.0)
       view_component (~> 3.5)
 
@@ -141,14 +141,14 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    net-imap (0.4.18)
+    net-imap (0.4.22)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.0)
     nokogiri (1.16.0-arm64-darwin)

--- a/app/assets/stylesheets/buildout_design_system/components/table.scss
+++ b/app/assets/stylesheets/buildout_design_system/components/table.scss
@@ -4,7 +4,6 @@
     border-collapse: separate;
     border-spacing: 0;
     margin: 0;
-    table-layout: fixed;
     white-space: nowrap;
     width: max-content;
     

--- a/lib/buildout_design_system/version.rb
+++ b/lib/buildout_design_system/version.rb
@@ -1,3 +1,3 @@
 module BuildoutDesignSystem
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/test/dummy/test/components/previews/buildout_design_system/table_preview/bordered.html.slim
+++ b/test/dummy/test/components/previews/buildout_design_system/table_preview/bordered.html.slim
@@ -6,7 +6,7 @@
       table.table.sticky-table style="width: max-content"
         thead
           tr.sticky-heading
-            th.sticky-cell style="width: 20vw"
+            th.sticky-cell
               | Name
             th style="width: 10vw"
               | Age


### PR DESCRIPTION
Fixes issue of the sticky cell not adhering to the width of the content in the latest chrome update.